### PR TITLE
Fix API endpoint `/_synapse/admin`

### DIFF
--- a/synapse-module/nginx.nix
+++ b/synapse-module/nginx.nix
@@ -227,7 +227,7 @@ in
           proxy_read_timeout 1h;
         '';
       };
-      locations."/_synapse/client" = {
+      locations."/_synapse" = {
         proxyPass = "http://$synapse_backend";
       };
     };


### PR DESCRIPTION
Got errors on pulling data from `/_synapse/admin`, turns out it was never redirected in nginx config