### PR TITLE
fix: don't force enableACME to allow useACMEHost

### DIFF
--- a/synapse-module/nginx.nix
+++ b/synapse-module/nginx.nix
@@ -198,7 +198,7 @@ in
     };
 
     services.nginx.virtualHosts."${cfg.public_baseurl}" = {
-      enableACME = true;
+      enableACME = lib.mkDefault true;
       forceSSL = true;
       locations."/_matrix" = {
         proxyPass = "http://$synapse_backend";


### PR DESCRIPTION
This is useful if you have many subdomains and want to avoid hitting the rate
limit, or avoid leaking the host IP to Let's Encrypt public logs. Alternately,
you can generate a certificate through enableACME. Note that this option does
not create any certificates, nor it does add subdomains to existing ones – you
will need to create them manually using security.acme.certs.